### PR TITLE
add inverse option in dump.cc

### DIFF
--- a/src/linear/dump.cc
+++ b/src/linear/dump.cc
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include "dmlc/io.h"
 #include "dmlc/logging.h"
+#include "base/localizer.h"
 
 using namespace std;
 using namespace dmlc;
@@ -12,7 +13,7 @@ class Dump {
  
  public:
 
-  Dump(string file_in, string file_out) : file_in_(file_in),file_out_(file_out) {}
+  Dump(string file_in, string file_out, bool need_inverse) : file_in_(file_in),file_out_(file_out), need_inverse_(need_inverse) {}
   ~Dump() {data_.clear();}
 
   // value type stored on sever nodes, can be also other Entrys
@@ -46,7 +47,8 @@ class Dump {
     int dumped = 0;
     for (const auto& it : data_) {
       if (it.second.Empty()) continue;
-      os << it.first << '\t' << it.second.w << '\t' << it.second.z << '\t' << it.second.sq_cum_grad <<'\n';  // check your entry
+      uint64_t feature_id = need_inverse_ ? ReverseBytes(it.first) : it.first;
+      os << feature_id << '\t' << it.second.w << '\t' << it.second.z << '\t' << it.second.sq_cum_grad <<'\n';  // check your entry
       dumped ++;
     }
     cout << "dumped " << dumped << " kv pairs\n";
@@ -61,23 +63,26 @@ class Dump {
   unordered_map<K, FTRLEntry> data_;
   string file_in_;
   string file_out_;
+  bool need_inverse_;
 };
 
 int main(int argc, char *argv[]) {
   if (argc < 3) {
-    cout << "Usage: <model_in> <dump_out>\n";
+    cout << "Usage: <model_in> <dump_out> [need_inverse]\n";
     return 0;
   }
   google::InitGoogleLogging(argv[0]);
   string model_in, dump_out;
+  bool need_inverse = false;
   for (int i = 1; i < argc; ++i) {
     char name[256], val[256];
     if (sscanf(argv[i], "%[^=]=%s", name, val) == 2) {
       if (!strcmp(name, "model_in")) model_in = val;
       if (!strcmp(name, "dump_out")) dump_out = val;
+      if (!strcmp(name, "need_inverse")) need_inverse = !strcmp(val, "0") ? false : true;
     }
   }
-  Dump d(model_in, dump_out);
+  Dump d(model_in, dump_out, need_inverse);
   d.run();
   return 0;
 }


### PR DESCRIPTION
Add inverse option in dump.cc. User can using build/dump.dmlc model_in=path dump_out=path need_inverse=1 to inverse the feature id. The need_inverse in optional, default with 0.
